### PR TITLE
docs(wiki): draft LLM wiki knowledge base scaffold

### DIFF
--- a/wiki/AGENTS.md
+++ b/wiki/AGENTS.md
@@ -1,0 +1,154 @@
+# LLM Wiki — Schema and Operating Manual
+
+This file is the schema for the LLM Wiki living under `wiki/`. It tells any LLM agent
+(Claude Code, Codex, etc.) how the wiki is organized and exactly what to do when the
+human asks to **ingest**, **query**, or **lint**. The pattern is from Andrej Karpathy's
+[LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
+
+The human curates sources and asks questions. The LLM does all the writing,
+cross-referencing, and bookkeeping. **Humans rarely edit wiki pages directly** —
+nudge the agent instead so the schema-driven invariants stay intact.
+
+## Directory layout
+
+```
+wiki/
+  AGENTS.md            # this file — the schema
+  README.md            # human-facing overview
+  index.md             # content catalog (LLM-maintained, every page listed)
+  log.md               # chronological append-only record of ingests/queries/lints
+  raw/                 # immutable source documents (PDFs, .md clippings, images)
+  pages/
+    entities/          # one page per concrete thing (service, person, product, library)
+    concepts/          # one page per idea/pattern (CQRS, saga, schema-per-feature)
+    sources/           # one summary page per item under raw/
+```
+
+The wiki is just markdown in git. No database, no embeddings — `index.md` plus
+`grep` is the search layer until size forces something heavier.
+
+## Page conventions
+
+Every page starts with YAML frontmatter so the index and any future Dataview-style
+tooling can parse it:
+
+```yaml
+---
+title: Schema-per-Feature
+type: concept            # entity | concept | source | analysis
+tags: [persistence, ddd, postgres]
+created: 2026-05-01
+updated: 2026-05-01
+sources: [sources/microcommerce-claude-md.md]
+---
+```
+
+Body sections, in order:
+
+1. **One-paragraph summary** — what this page is about, written so the reader can
+   stop after the first paragraph and still know the answer.
+2. **Body** — the actual content. Use H2/H3. Keep it tight.
+3. **Cross-references** — bulleted list of `[[wiki links]]` to related pages.
+4. **Sources** — bulleted list of `sources/*.md` pages this content draws from,
+   with the specific claim each source backs up where non-obvious.
+
+Filenames are `kebab-case.md`. Page titles are Title Case. Internal links use
+relative paths (`../concepts/cqrs.md`) so they survive being moved into Obsidian
+or rendered on GitHub.
+
+## The three operations
+
+### 1. Ingest
+
+Trigger: human drops a file into `raw/` (or pastes a URL) and says "ingest this".
+
+Steps:
+
+1. Read the source end to end. If it's a URL, fetch it and save a markdown
+   clipping into `raw/` first so the source is captured immutably.
+2. Discuss the key takeaways with the human in chat — **before** writing.
+   Confirm scope: what's worth filing, what's noise.
+3. Create `pages/sources/<slug>.md` with frontmatter, a one-paragraph summary,
+   the takeaways, and verbatim quotes for any claim likely to be cited later.
+4. Touch every wiki page the source affects:
+   - update or create relevant `entities/` and `concepts/` pages
+   - add cross-references both directions (if A links to B, B links to A)
+   - flag contradictions explicitly: `> ⚠️ Contradicts [[other-page]] (2026-04-12): …`
+5. Update `index.md` — every new page gets listed under the right category.
+6. Append one line to `log.md` using the format below.
+
+A single ingest typically touches 5–15 pages. That's normal.
+
+### 2. Query
+
+Trigger: human asks a question.
+
+Steps:
+
+1. Read `index.md` first. Pick the 3–8 pages most likely to contain the answer.
+2. Read those pages. If they cite source pages, follow the citations only when
+   the wiki page is ambiguous or thin.
+3. Answer with citations: every non-trivial claim links to the wiki page (and
+   transitively the source) it came from.
+4. **If the answer is novel or non-trivial, offer to file it back** as
+   `pages/concepts/<slug>.md` or `pages/analysis/<slug>.md`. Synthesis should
+   compound, not vanish into chat history.
+
+Answer format follows the question — a paragraph for simple questions, a table
+for comparisons, a markdown page for anything worth keeping.
+
+### 3. Lint
+
+Trigger: human says "lint the wiki" (do this every ~10 ingests).
+
+Check for:
+
+- **Contradictions** — pages making opposing claims without a `⚠️ Contradicts` note.
+- **Stale claims** — superseded by a newer source but not yet revised.
+- **Orphans** — pages with zero inbound links (probably mis-categorized).
+- **Missing pages** — concepts mentioned ≥3 times across the wiki but lacking
+  their own page.
+- **Broken links** — internal `[[...]]` or relative paths that don't resolve.
+- **Index drift** — pages on disk not in `index.md`, or vice versa.
+
+Output a punch list. Fix what's safe (typos, broken links, index drift).
+For substantive issues (contradictions, missing pages), propose changes and
+wait for the human.
+
+## index.md format
+
+Grouped by category. Each line: `- [Title](relative/path.md) — one-line summary`.
+Categories in order: Entities, Concepts, Sources, Analyses. Append-only when
+ingesting; rewrite during lint.
+
+## log.md format
+
+Append-only, one entry per operation. Each entry starts with a parseable header:
+
+```
+## [YYYY-MM-DD] <op> | <subject>
+
+- pages touched: ...
+- notes: ...
+```
+
+`<op>` is one of `ingest`, `query`, `lint`, `analysis`. Consistent prefixes
+mean `grep "^## \[" wiki/log.md | tail -20` always works as a recent-activity feed.
+
+## Scope of this particular wiki
+
+This wiki is seeded as a **knowledge base about the MicroCommerce codebase
+itself** — architecture, patterns, decisions, libraries. The first sources are
+the project's own docs (`CLAUDE.md`, `README.md`, `docs/`). It can be repointed
+to any domain by replacing the seed pages and editing this section; the
+operating manual above stays unchanged.
+
+## What the LLM must NOT do
+
+- Don't edit anything under `raw/`. Sources are immutable.
+- Don't delete pages without asking. Stale pages get marked, not removed.
+- Don't fabricate citations. Every source link must resolve to a real
+  `pages/sources/*.md` file backed by something in `raw/`.
+- Don't skip `log.md`. The log is the audit trail.
+- Don't expand scope silently. If an ingest touches a new domain not yet in
+  the wiki, surface that to the human first.

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,74 @@
+# Wiki
+
+An LLM-maintained knowledge base built on Andrej Karpathy's
+[LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
+
+The idea: instead of treating documents as a RAG store the LLM re-reads on
+every question, the LLM **incrementally compiles** what it learns into a
+persistent, interlinked set of markdown pages. Synthesis happens once at
+ingest time and stays current. Queries read pre-compiled pages, not raw
+documents. The wiki is a compounding artifact.
+
+## What's where
+
+| Path | Purpose |
+|---|---|
+| `AGENTS.md` | Schema — the operating manual every LLM agent must follow |
+| `index.md` | Content catalog — every page listed by category |
+| `log.md` | Chronological, append-only record of ingests/queries/lints |
+| `raw/` | Immutable source documents (LLM reads, never writes) |
+| `pages/entities/` | One page per concrete thing (service, library, person) |
+| `pages/concepts/` | One page per idea or pattern |
+| `pages/sources/` | One summary page per item under `raw/` |
+
+## How to use it
+
+The three operations, all driven from chat:
+
+- **Ingest** — `"Ingest wiki/raw/<file>"` (or paste a URL). The LLM clips
+  the source if needed, summarizes, files a `pages/sources/<slug>.md`,
+  updates affected entity/concept pages, refreshes `index.md`, and appends
+  to `log.md`.
+- **Query** — Ask a question. The LLM consults `index.md` first, then drills
+  into the relevant pages. If the answer is non-trivial it offers to file
+  it back as a permanent analysis page.
+- **Lint** — `"Lint the wiki"` (do this every ~10 ingests). The LLM finds
+  contradictions, orphans, stale claims, missing pages, broken links, and
+  index drift, then proposes fixes.
+
+The full conventions live in [`AGENTS.md`](./AGENTS.md). Read that before
+asking the LLM to do anything substantive.
+
+## Current scope
+
+Seeded as a knowledge base **about the MicroCommerce codebase itself** —
+the project's architecture, patterns, libraries, and decisions. The first
+real source is the repo's own `CLAUDE.md`. To repurpose it for a different
+domain, edit the *Scope* section of `AGENTS.md` and replace the seed
+pages — the operating manual stays the same.
+
+## Editing rules for humans
+
+- **Don't edit `pages/` directly.** Tell the agent what's wrong instead;
+  the schema invariants (cross-references, index, log) only stay consistent
+  when one party owns the writes.
+- **Do drop sources into `raw/`.** That's how you grow the wiki.
+- **Do fix `AGENTS.md`** when a convention isn't working. The schema is
+  meant to co-evolve.
+
+## Tooling tips
+
+- The wiki is plain markdown in git, so version history, branching, and
+  collaboration come for free.
+- It also opens cleanly in **Obsidian** — point a vault at `wiki/` and you
+  get the graph view, backlinks, and the Web Clipper for free.
+- At small scale `index.md` + `grep` is the search layer. Reach for
+  [qmd](https://github.com/tobi/qmd) (BM25/vector hybrid + MCP) only when
+  the index file gets unwieldy.
+
+## See also
+
+- [`pages/sources/karpathy-llm-wiki.md`](./pages/sources/karpathy-llm-wiki.md)
+  — summary of the source pattern this wiki implements
+- [`raw/karpathy-llm-wiki.md`](./raw/karpathy-llm-wiki.md) — verbatim copy
+  of the original gist

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,29 @@
+# Wiki Index
+
+Catalog of every page in the wiki. The LLM updates this on every ingest and
+rebuilds it during a lint pass. Read this first when answering a query.
+
+Categories: **Entities** (concrete things), **Concepts** (ideas/patterns),
+**Sources** (one summary per item in `raw/`), **Analyses** (synthesis pages
+filed back from queries).
+
+## Entities
+
+- [MicroCommerce Platform](pages/entities/microcommerce-platform.md) — the showcase e-commerce system this wiki is currently scoped to
+- [ApiService](pages/entities/api-service.md) — modular-monolith ASP.NET Core backend hosting all feature slices
+- [YARP Gateway](pages/entities/yarp-gateway.md) — reverse proxy fronting ApiService (CORS, rate limiting, auth, request IDs)
+
+## Concepts
+
+- [Schema-per-Feature](pages/concepts/schema-per-feature.md) — single Postgres database `appdb`, one schema per vertical slice
+- [CQRS with MediatR](pages/concepts/cqrs-mediatr.md) — commands/queries split, validation + result-checking pipeline behaviors
+- [Checkout Saga](pages/concepts/checkout-saga.md) — MassTransit state machine orchestrating reservation → payment → confirm
+
+## Sources
+
+- [MicroCommerce CLAUDE.md](pages/sources/microcommerce-claude-md.md) — project conventions, tech stack, architecture overview (root `CLAUDE.md`)
+- [Karpathy LLM Wiki gist](pages/sources/karpathy-llm-wiki.md) — the original pattern this wiki implements
+
+## Analyses
+
+_(none yet — file synthesis here when queries produce keepers)_

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,0 +1,20 @@
+# Wiki Log
+
+Append-only chronological record of every operation against the wiki. New
+entries go at the bottom. Each entry header follows
+`## [YYYY-MM-DD] <op> | <subject>` so recent activity is greppable:
+
+```
+grep "^## \[" wiki/log.md | tail -20
+```
+
+---
+
+## [2026-05-01] init | wiki scaffold
+
+- created: `AGENTS.md`, `README.md`, `index.md`, `log.md`
+- created: `pages/entities/`, `pages/concepts/`, `pages/sources/`, `raw/`
+- seeded entity pages: `microcommerce-platform`, `api-service`, `yarp-gateway`
+- seeded concept pages: `schema-per-feature`, `cqrs-mediatr`, `checkout-saga`
+- seeded source pages: `microcommerce-claude-md`, `karpathy-llm-wiki`
+- notes: scoped to MicroCommerce codebase; first real sources are the repo's own docs

--- a/wiki/pages/concepts/checkout-saga.md
+++ b/wiki/pages/concepts/checkout-saga.md
@@ -1,0 +1,54 @@
+---
+title: Checkout Saga
+type: concept
+tags: [saga, masstransit, ordering, inventory, payments]
+created: 2026-05-01
+updated: 2026-05-01
+sources: [../sources/microcommerce-claude-md.md]
+---
+
+The checkout flow is orchestrated by `CheckoutStateMachine`, a MassTransit
+state machine living in `Features/Ordering/Application/Saga/`. It coordinates
+the cross-slice steps that turn a cart into a confirmed order: reserve stock
+in **Inventory**, charge the customer via **Payments**, then confirm or fail
+the order in **Ordering**.
+
+## State machine outline
+
+```
+[Started]
+   │ OrderPlaced
+   ▼
+[AwaitingStockReservation]
+   │ StockReserved      │ StockReservationFailed
+   ▼                    ▼
+[AwaitingPayment]      [Failed]
+   │ PaymentSucceeded   │ PaymentFailed
+   ▼                    ▼
+[Confirmed]            [Failed → compensate: ReleaseStock]
+```
+
+State is persisted in the `ordering` schema via EF Core, so saga instances
+survive restarts.
+
+## Reliability building blocks
+
+- **Transactional outbox** — `OutboxDbContext` in the `outbox` schema gives
+  inbox deduplication and outbox delivery. Domain events are published only
+  after the database transaction commits.
+- **Retries + circuit breaker** — global MassTransit config: exponential
+  backoff `[1s, 5s, 25s]`, circuit breaker tripping at 15% failure rate.
+- **Dead letter queue** — `DeadLetterQueueService` exposes failed messages
+  through the **Messaging** feature for manual replay.
+- **Transport** — Azure Service Bus locally (via the emulator under Aspire),
+  RabbitMQ in Kubernetes; selection is conditional in `Program.cs`.
+
+## Cross-references
+
+- [[api-service]] — hosts the saga
+- [[cqrs-mediatr]] — saga reacts to events emitted by command handlers
+- [[schema-per-feature]] — saga state in `ordering`, outbox in `outbox`
+
+## Sources
+
+- [microcommerce-claude-md](../sources/microcommerce-claude-md.md) — "Checkout Saga: CheckoutStateMachine orchestrates stock reservation -> payment -> confirm/fail with EF Core-persisted state"

--- a/wiki/pages/concepts/cqrs-mediatr.md
+++ b/wiki/pages/concepts/cqrs-mediatr.md
@@ -1,0 +1,45 @@
+---
+title: CQRS with MediatR
+type: concept
+tags: [cqrs, mediatr, validation, fluentresults]
+created: 2026-05-01
+updated: 2026-05-01
+sources: [../sources/microcommerce-claude-md.md]
+---
+
+Inside each feature slice, write operations are commands and read operations
+are queries — both are MediatR `IRequest<T>` records dispatched through a
+shared pipeline. Handlers are thin: validate input, run domain logic on
+aggregates, return either a DTO or a `Result<T>`.
+
+## Pipeline behaviors
+
+Two behaviors run around every handler, defined in
+`Common/Behaviors/`:
+
+1. **`ValidationBehavior`** — runs FluentValidation validators registered for
+   the request type. Validation failures short-circuit the pipeline before the
+   handler executes.
+2. **`ResultValidationBehavior`** — when a handler returns a FluentResults
+   `Result<T>`, this behavior translates `IsFailed` outcomes into 422 responses
+   via the FluentResults → HTTP mapper in `Common/Extensions/`.
+
+## Conventions
+
+- Commands and queries are records (`public sealed record CreateOrderCommand(...)`).
+- Handlers live next to their request under `Application/Commands/` or
+  `Application/Queries/`.
+- I/O is always async; no `.Result` / `.Wait()` (enforced by the project's
+  C# conventions).
+- Domain events are raised on aggregates and published *after* `SaveChanges`
+  by `DomainEventInterceptor`, so a failed transaction never leaks events.
+
+## Cross-references
+
+- [[api-service]] — hosts the MediatR registration and pipeline
+- [[schema-per-feature]] — handlers depend on the slice's owned DbContext
+- [[checkout-saga]] — saga consumes commands/events produced by handlers
+
+## Sources
+
+- [microcommerce-claude-md](../sources/microcommerce-claude-md.md) — "Commands and queries via MediatR with pipeline behaviors (ValidationBehavior, ResultValidationBehavior)"

--- a/wiki/pages/concepts/schema-per-feature.md
+++ b/wiki/pages/concepts/schema-per-feature.md
@@ -1,0 +1,50 @@
+---
+title: Schema-per-Feature
+type: concept
+tags: [persistence, ef-core, postgres, ddd]
+created: 2026-05-01
+updated: 2026-05-01
+sources: [../sources/microcommerce-claude-md.md]
+---
+
+Every feature slice owns its own EF Core `DbContext` and its own Postgres
+schema, but they all share a single physical database (`appdb`). This keeps
+deployment simple (one connection string, one backup) while enforcing logical
+isolation that makes future extraction into separate services cheap.
+
+## How it works
+
+- Each `Features/<Name>/Infrastructure/<Name>DbContext.cs` declares its schema
+  in `OnModelCreating`.
+- Schemas in use: `catalog`, `cart`, `ordering`, `inventory`, `profiles`,
+  `reviews`, `wishlists`, plus a shared `outbox` for MassTransit's transactional
+  outbox.
+- Migrations are per-feature (under each slice's `Infrastructure/Migrations/`),
+  not global.
+- All contexts inherit from `BaseDbContext`, which wires the audit/concurrency/
+  soft-delete/domain-event interceptors and applies `UseSnakeCaseNamingConvention()`.
+
+## Why this and not separate databases
+
+- Local dev and integration tests stay fast — one Postgres container, not eight.
+- Cross-slice queries are still impossible in code (each slice only sees its own
+  context), so the boundary is enforced where it matters.
+- Lifting a slice out later means: point its `DbContext` at a new database,
+  copy the schema, repoint the connection string. No code change inside the slice.
+
+## Trade-offs
+
+- A single `DROP DATABASE` wipes everything. Backup strategy must treat the
+  whole `appdb` as one unit.
+- A long-running migration on one schema can lock shared catalog tables in
+  Postgres if you're not careful.
+
+## Cross-references
+
+- [[api-service]]
+- [[cqrs-mediatr]] — handlers depend on the per-slice DbContext
+- [[checkout-saga]] — saga state lives in the `ordering` schema, outbox in `outbox`
+
+## Sources
+
+- [microcommerce-claude-md](../sources/microcommerce-claude-md.md) — "Schema-per-Feature: All DbContexts share one `appdb` PostgreSQL database with separate schemas"

--- a/wiki/pages/entities/api-service.md
+++ b/wiki/pages/entities/api-service.md
@@ -1,0 +1,51 @@
+---
+title: ApiService
+type: entity
+tags: [backend, dotnet, aspnetcore, modular-monolith]
+created: 2026-05-01
+updated: 2026-05-01
+sources: [../sources/microcommerce-claude-md.md]
+---
+
+`MicroCommerce.ApiService` is the single ASP.NET Core process that hosts every
+feature slice. It is a modular monolith — one deployable, but each feature
+owns its own `DbContext`, schema, and message contracts so individual slices
+can be lifted out into separate services later without rewrites.
+
+## Stack
+
+- .NET 10, ASP.NET Core Minimal APIs
+- MediatR for [[cqrs-mediatr]]; pipeline behaviors `ValidationBehavior`,
+  `ResultValidationBehavior`
+- EF Core with `UseSnakeCaseNamingConvention()` and per-slice DbContexts over
+  one Postgres database (`appdb`, [[schema-per-feature]])
+- MassTransit on Azure Service Bus (Aspire/dev) or RabbitMQ (Kubernetes),
+  switched conditionally in `Program.cs`
+- Vogen strongly-typed IDs, Ardalis.SmartEnum domain enums,
+  Ardalis.Specification for queries, FluentValidation for input,
+  FluentResults for railway-oriented errors
+
+## Cross-cutting infrastructure
+
+Lives under `src/MicroCommerce.ApiService/Common/`:
+
+- **Behaviors** — MediatR pipeline (validation, result validation)
+- **Persistence** — `BaseDbContext`, EF interceptors
+  (`AuditInterceptor`, `ConcurrencyInterceptor`, `SoftDeleteInterceptor`,
+  `DomainEventInterceptor`), conventions, and the MassTransit `OutboxDbContext`
+- **Messaging** — `DeadLetterQueueService`, `DomainEventFaultConsumer`
+- **Exceptions** — global exception handling
+- **Extensions** — FluentResults → HTTP status mapping
+- **OpenApi** — schema transformers for Vogen IDs and SmartEnums
+
+## Cross-references
+
+- [[microcommerce-platform]] — the overall system
+- [[yarp-gateway]] — the only thing that should call this in prod
+- [[cqrs-mediatr]]
+- [[schema-per-feature]]
+- [[checkout-saga]]
+
+## Sources
+
+- [microcommerce-claude-md](../sources/microcommerce-claude-md.md)

--- a/wiki/pages/entities/microcommerce-platform.md
+++ b/wiki/pages/entities/microcommerce-platform.md
@@ -1,0 +1,58 @@
+---
+title: MicroCommerce Platform
+type: entity
+tags: [platform, overview]
+created: 2026-05-01
+updated: 2026-05-01
+sources: [../sources/microcommerce-claude-md.md]
+---
+
+MicroCommerce is a showcase e-commerce platform that demonstrates a modern .NET
+modular-monolith intentionally designed for gradual extraction into microservices.
+A Next.js storefront talks through a YARP gateway to a single ASP.NET Core
+backend whose features are organized as vertical slices.
+
+## Topology
+
+```
+Next.js (MicroCommerce.Web)
+    │
+    ▼
+YARP Gateway (MicroCommerce.Gateway)  ◀── CORS, rate limit, auth, X-Request-ID
+    │
+    ▼
+ApiService (MicroCommerce.ApiService)
+    │
+    ▼
+PostgreSQL (appdb, schema-per-feature)
+```
+
+Aspire (`MicroCommerce.AppHost`) is the entry point for local dev and wires
+PostgreSQL → ApiService → Gateway → Frontend together. The frontend resolves
+the gateway URL via the Aspire-injected `services__gateway__https__0` env var.
+
+## Feature slices
+
+Each lives under `src/MicroCommerce.ApiService/Features/<Name>/` with its own
+`Domain/Application/Infrastructure` folders and an owned `DbContext`:
+
+- **Catalog** — products, categories, images
+- **Cart** — guest + authenticated shopping cart
+- **Ordering** — checkout, orders, the [[checkout-saga]]
+- **Inventory** — stock management
+- **Profiles** — user profiles, addresses, avatars
+- **Reviews** — verified-purchase product reviews
+- **Wishlists** — authenticated user wishlists
+- **Messaging** — dead letter queue UI
+
+## Cross-references
+
+- [[api-service]] — the backend hosting all slices
+- [[yarp-gateway]] — the reverse proxy in front of it
+- [[schema-per-feature]] — the persistence pattern
+- [[cqrs-mediatr]] — the command/query pattern inside each slice
+- [[checkout-saga]] — the cross-slice workflow
+
+## Sources
+
+- [microcommerce-claude-md](../sources/microcommerce-claude-md.md) — entire page derived from this

--- a/wiki/pages/entities/yarp-gateway.md
+++ b/wiki/pages/entities/yarp-gateway.md
@@ -1,0 +1,32 @@
+---
+title: YARP Gateway
+type: entity
+tags: [gateway, yarp, reverse-proxy]
+created: 2026-05-01
+updated: 2026-05-01
+sources: [../sources/microcommerce-claude-md.md]
+---
+
+`MicroCommerce.Gateway` is a YARP reverse proxy that sits between the Next.js
+frontend and the [[api-service]]. It centralizes cross-cutting HTTP concerns so
+the backend slices stay focused on domain logic.
+
+## Responsibilities
+
+- **CORS** — single allow-list for the storefront and admin origins
+- **Rate limiting** — sliding-window policies applied per route
+- **Auth** — JWT validation against Keycloak before traffic reaches the backend
+- **Request correlation** — injects `X-Request-ID` for distributed tracing
+
+The frontend always routes through the gateway; it never calls `ApiService`
+directly. Aspire injects the gateway URL into the frontend as
+`services__gateway__https__0`, exposed to the browser via `/api/config`.
+
+## Cross-references
+
+- [[microcommerce-platform]]
+- [[api-service]]
+
+## Sources
+
+- [microcommerce-claude-md](../sources/microcommerce-claude-md.md)

--- a/wiki/pages/sources/karpathy-llm-wiki.md
+++ b/wiki/pages/sources/karpathy-llm-wiki.md
@@ -1,0 +1,52 @@
+---
+title: "Source: Karpathy — LLM Wiki"
+type: source
+tags: [meta, methodology, knowledge-management]
+created: 2026-05-01
+updated: 2026-05-01
+url: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+raw: ../../raw/karpathy-llm-wiki.md
+---
+
+Andrej Karpathy's gist describing the "LLM Wiki" pattern: an LLM-maintained,
+persistent, interlinked markdown knowledge base that sits between the human
+and their raw sources. This wiki is a direct instantiation of that pattern.
+
+## Key takeaways
+
+- **Compounding artifact, not RAG.** The wiki is built and maintained
+  incrementally. Synthesis happens once at ingest time and stays current,
+  rather than being re-derived from raw documents on every query.
+- **Three layers**: raw sources (immutable) → wiki (LLM-owned markdown) →
+  schema (the operating manual, e.g. `AGENTS.md` / `CLAUDE.md`).
+- **Three operations**: **ingest** new sources (touches 5–15 wiki pages),
+  **query** the wiki (cite pages, optionally file synthesis back), **lint**
+  for contradictions/orphans/stale claims/missing pages.
+- **Two special files**: `index.md` (content-oriented catalog) and `log.md`
+  (chronological, append-only, parseable header per entry).
+- **Human role**: source curation, exploration, asking the right questions.
+- **LLM role**: summarizing, cross-referencing, filing, bookkeeping —
+  exactly the maintenance burden that causes humans to abandon wikis.
+- **Storage**: just markdown in git. No database, no embeddings required at
+  small/medium scale.
+- **Spirit**: Vannevar Bush's Memex (1945), but with the LLM doing the
+  associative-trail maintenance Bush couldn't solve.
+
+## Why this page exists
+
+This source justifies the **shape** of the wiki — `AGENTS.md`, `index.md`,
+`log.md`, and the ingest/query/lint vocabulary all come from here. When the
+human asks "why is the schema set up this way?", point them at this page.
+
+## Pages derived from this source
+
+- [[../../AGENTS.md]] — the wiki's operating manual
+- [[../../README.md]] — human-facing overview
+
+## Raw
+
+- Captured locally: `wiki/raw/karpathy-llm-wiki.md` (verbatim copy).
+- Original: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f.
+
+Treat the local copy as authoritative for citation purposes — the gist URL
+may change, but the captured file will not.

--- a/wiki/pages/sources/microcommerce-claude-md.md
+++ b/wiki/pages/sources/microcommerce-claude-md.md
@@ -1,0 +1,53 @@
+---
+title: "Source: MicroCommerce CLAUDE.md"
+type: source
+tags: [project-docs, conventions, architecture]
+created: 2026-05-01
+updated: 2026-05-01
+raw: ../../../CLAUDE.md
+---
+
+The project's root `CLAUDE.md` — the single canonical document describing the
+MicroCommerce platform's tech stack, project structure, conventions, and the
+key patterns in use. It is the seed source for almost every page in this wiki.
+
+## Key takeaways
+
+- **Topology**: Aspire orchestrates Postgres → ApiService → YARP Gateway →
+  Next.js frontend. Frontend never bypasses the gateway.
+- **Architecture style**: modular monolith, vertical-slice features, intentionally
+  shaped for later extraction into microservices.
+- **Persistence**: schema-per-feature inside one shared `appdb` Postgres
+  database; EF Core with snake_case convention; per-feature migrations.
+- **Application pattern**: CQRS via MediatR with `ValidationBehavior` and
+  `ResultValidationBehavior` in the pipeline.
+- **Messaging**: MassTransit on Azure Service Bus (dev) or RabbitMQ (k8s);
+  transactional outbox in its own schema; circuit breaker + exponential retry.
+- **Cross-cutting**: Vogen strongly-typed IDs, Ardalis.SmartEnum domain enums,
+  Ardalis.Specification for queries, FluentValidation for input, FluentResults
+  for railway-style error returns.
+- **Conventions**: file-scoped namespaces, primary constructors for DI,
+  explicit types over `var`, records for DTOs/commands/queries, UUID v7 for
+  new entity IDs, `TreatWarningsAsErrors`, nullable reference types on.
+- **Frontend**: Next.js 16 + React 19 + TS strict, Tailwind v4, TanStack Query,
+  Server Components by default, Biome for linting/formatting (kebab-case files,
+  PascalCase components, `@/*` path alias).
+- **Testing**: xUnit + Testcontainers (real Postgres) + MassTransit
+  TestFramework for the backend; Playwright E2E for the frontend.
+- **Auth**: Keycloak realm config under `MicroCommerce.AppHost/Realms/`;
+  NextAuth.js v5 on the frontend.
+
+## Pages derived from this source
+
+- [[../entities/microcommerce-platform]]
+- [[../entities/api-service]]
+- [[../entities/yarp-gateway]]
+- [[../concepts/schema-per-feature]]
+- [[../concepts/cqrs-mediatr]]
+- [[../concepts/checkout-saga]]
+
+## Raw
+
+`../../../CLAUDE.md` (repo root). Treat as immutable for wiki purposes — it is
+maintained as project documentation, not as a wiki source per se, but the
+content is canonical.

--- a/wiki/raw/karpathy-llm-wiki.md
+++ b/wiki/raw/karpathy-llm-wiki.md
@@ -1,0 +1,79 @@
+# LLM Wiki
+
+A pattern for building personal knowledge bases using LLMs.
+
+This is an idea file, it is designed to be copy pasted to your own LLM Agent (e.g. OpenAI Codex, Claude Code, OpenCode / Pi, or etc.). Its goal is to communicate the high level idea, but your agent will build out the specifics in collaboration with you.
+
+## The core idea
+
+Most people's experience with LLMs and documents looks like RAG: you upload a collection of files, the LLM retrieves relevant chunks at query time, and generates an answer. This works, but the LLM is rediscovering knowledge from scratch on every question. There's no accumulation. Ask a subtle question that requires synthesizing five documents, and the LLM has to find and piece together the relevant fragments every time. Nothing is built up. NotebookLM, ChatGPT file uploads, and most RAG systems work this way.
+
+The idea here is different. Instead of just retrieving from raw documents at query time, the LLM **incrementally builds and maintains a persistent wiki** — a structured, interlinked collection of markdown files that sits between you and the raw sources. When you add a new source, the LLM doesn't just index it for later retrieval. It reads it, extracts the key information, and integrates it into the existing wiki — updating entity pages, revising topic summaries, noting where new data contradicts old claims, strengthening or challenging the evolving synthesis. The knowledge is compiled once and then *kept current*, not re-derived on every query.
+
+This is the key difference: **the wiki is a persistent, compounding artifact.** The cross-references are already there. The contradictions have already been flagged. The synthesis already reflects everything you've read. The wiki keeps getting richer with every source you add and every question you ask.
+
+You never (or rarely) write the wiki yourself — the LLM writes and maintains all of it. You're in charge of sourcing, exploration, and asking the right questions. The LLM does all the grunt work — the summarizing, cross-referencing, filing, and bookkeeping that makes a knowledge base actually useful over time. In practice, I have the LLM agent open on one side and Obsidian open on the other. The LLM makes edits based on our conversation, and I browse the results in real time — following links, checking the graph view, reading the updated pages. Obsidian is the IDE; the LLM is the programmer; the wiki is the codebase.
+
+This can apply to a lot of different contexts. A few examples:
+
+- **Personal**: tracking your own goals, health, psychology, self-improvement — filing journal entries, articles, podcast notes, and building up a structured picture of yourself over time.
+- **Research**: going deep on a topic over weeks or months — reading papers, articles, reports, and incrementally building a comprehensive wiki with an evolving thesis.
+- **Reading a book**: filing each chapter as you go, building out pages for characters, themes, plot threads, and how they connect. By the end you have a rich companion wiki. Think of fan wikis like [Tolkien Gateway](https://tolkiengateway.net/wiki/Main_Page) — thousands of interlinked pages covering characters, places, events, languages, built by a community of volunteers over years. You could build something like that personally as you read, with the LLM doing all the cross-referencing and maintenance.
+- **Business/team**: an internal wiki maintained by LLMs, fed by Slack threads, meeting transcripts, project documents, customer calls. Possibly with humans in the loop reviewing updates. The wiki stays current because the LLM does the maintenance that no one on the team wants to do.
+- **Competitive analysis, due diligence, trip planning, course notes, hobby deep-dives** — anything where you're accumulating knowledge over time and want it organized rather than scattered.
+
+## Architecture
+
+There are three layers:
+
+**Raw sources** — your curated collection of source documents. Articles, papers, images, data files. These are immutable — the LLM reads from them but never modifies them. This is your source of truth.
+
+**The wiki** — a directory of LLM-generated markdown files. Summaries, entity pages, concept pages, comparisons, an overview, a synthesis. The LLM owns this layer entirely. It creates pages, updates them when new sources arrive, maintains cross-references, and keeps everything consistent. You read it; the LLM writes it.
+
+**The schema** — a document (e.g. CLAUDE.md for Claude Code or AGENTS.md for Codex) that tells the LLM how the wiki is structured, what the conventions are, and what workflows to follow when ingesting sources, answering questions, or maintaining the wiki. This is the key configuration file — it's what makes the LLM a disciplined wiki maintainer rather than a generic chatbot. You and the LLM co-evolve this over time as you figure out what works for your domain.
+
+## Operations
+
+**Ingest.** You drop a new source into the raw collection and tell the LLM to process it. An example flow: the LLM reads the source, discusses key takeaways with you, writes a summary page in the wiki, updates the index, updates relevant entity and concept pages across the wiki, and appends an entry to the log. A single source might touch 10-15 wiki pages. Personally I prefer to ingest sources one at a time and stay involved — I read the summaries, check the updates, and guide the LLM on what to emphasize. But you could also batch-ingest many sources at once with less supervision. It's up to you to develop the workflow that fits your style and document it in the schema for future sessions.
+
+**Query.** You ask questions against the wiki. The LLM searches for relevant pages, reads them, and synthesizes an answer with citations. Answers can take different forms depending on the question — a markdown page, a comparison table, a slide deck (Marp), a chart (matplotlib), a canvas. The important insight: **good answers can be filed back into the wiki as new pages.** A comparison you asked for, an analysis, a connection you discovered — these are valuable and shouldn't disappear into chat history. This way your explorations compound in the knowledge base just like ingested sources do.
+
+**Lint.** Periodically, ask the LLM to health-check the wiki. Look for: contradictions between pages, stale claims that newer sources have superseded, orphan pages with no inbound links, important concepts mentioned but lacking their own page, missing cross-references, data gaps that could be filled with a web search. The LLM is good at suggesting new questions to investigate and new sources to look for. This keeps the wiki healthy as it grows.
+
+## Indexing and logging
+
+Two special files help the LLM (and you) navigate the wiki as it grows. They serve different purposes:
+
+**index.md** is content-oriented. It's a catalog of everything in the wiki — each page listed with a link, a one-line summary, and optionally metadata like date or source count. Organized by category (entities, concepts, sources, etc.). The LLM updates it on every ingest. When answering a query, the LLM reads the index first to find relevant pages, then drills into them. This works surprisingly well at moderate scale (~100 sources, ~hundreds of pages) and avoids the need for embedding-based RAG infrastructure.
+
+**log.md** is chronological. It's an append-only record of what happened and when — ingests, queries, lint passes. A useful tip: if each entry starts with a consistent prefix (e.g. `## [2026-04-02] ingest | Article Title`), the log becomes parseable with simple unix tools — `grep "^## \[" log.md | tail -5` gives you the last 5 entries. The log gives you a timeline of the wiki's evolution and helps the LLM understand what's been done recently.
+
+## Optional: CLI tools
+
+At some point you may want to build small tools that help the LLM operate on the wiki more efficiently. A search engine over the wiki pages is the most obvious one — at small scale the index file is enough, but as the wiki grows you want proper search. [qmd](https://github.com/tobi/qmd) is a good option: it's a local search engine for markdown files with hybrid BM25/vector search and LLM re-ranking, all on-device. It has both a CLI (so the LLM can shell out to it) and an MCP server (so the LLM can use it as a native tool). You could also build something simpler yourself — the LLM can help you vibe-code a naive search script as the need arises.
+
+## Tips and tricks
+
+- **Obsidian Web Clipper** is a browser extension that converts web articles to markdown. Very useful for quickly getting sources into your raw collection.
+- **Download images locally.** In Obsidian Settings → Files and links, set "Attachment folder path" to a fixed directory (e.g. `raw/assets/`). Then in Settings → Hotkeys, search for "Download" to find "Download attachments for current file" and bind it to a hotkey (e.g. Ctrl+Shift+D). After clipping an article, hit the hotkey and all images get downloaded to local disk. This is optional but useful — it lets the LLM view and reference images directly instead of relying on URLs that may break. Note that LLMs can't natively read markdown with inline images in one pass — the workaround is to have the LLM read the text first, then view some or all of the referenced images separately to gain additional context. It's a bit clunky but works well enough.
+- **Obsidian's graph view** is the best way to see the shape of your wiki — what's connected to what, which pages are hubs, which are orphans.
+- **Marp** is a markdown-based slide deck format. Obsidian has a plugin for it. Useful for generating presentations directly from wiki content.
+- **Dataview** is an Obsidian plugin that runs queries over page frontmatter. If your LLM adds YAML frontmatter to wiki pages (tags, dates, source counts), Dataview can generate dynamic tables and lists.
+- The wiki is just a git repo of markdown files. You get version history, branching, and collaboration for free.
+
+## Why this works
+
+The tedious part of maintaining a knowledge base is not the reading or the thinking — it's the bookkeeping. Updating cross-references, keeping summaries current, noting when new data contradicts old claims, maintaining consistency across dozens of pages. Humans abandon wikis because the maintenance burden grows faster than the value. LLMs don't get bored, don't forget to update a cross-reference, and can touch 15 files in one pass. The wiki stays maintained because the cost of maintenance is near zero.
+
+The human's job is to curate sources, direct the analysis, ask good questions, and think about what it all means. The LLM's job is everything else.
+
+The idea is related in spirit to Vannevar Bush's Memex (1945) — a personal, curated knowledge store with associative trails between documents. Bush's vision was closer to this than to what the web became: private, actively curated, with the connections between documents as valuable as the documents themselves. The part he couldn't solve was who does the maintenance. The LLM handles that.
+
+## Note
+
+This document is intentionally abstract. It describes the idea, not a specific implementation. The exact directory structure, the schema conventions, the page formats, the tooling — all of that will depend on your domain, your preferences, and your LLM of choice. Everything mentioned above is optional and modular — pick what's useful, ignore what isn't. For example: your sources might be text-only, so you don't need image handling at all. Your wiki might be small enough that the index file is all you need, no search engine required. You might not care about slide decks and just want markdown pages. You might want a completely different set of output formats. The right way to use this is to share it with your LLM agent and work together to instantiate a version that fits your needs. The document's only job is to communicate the pattern. Your LLM can figure out the rest.
+
+---
+
+Source: https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f
+Captured: 2026-05-01


### PR DESCRIPTION
Implements Karpathy's LLM Wiki pattern (gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)
as a three-layer structure under wiki/:

- raw/    — immutable source documents (LLM reads, never writes)
- pages/  — LLM-owned markdown (entities, concepts, sources, analyses)
- AGENTS.md, index.md, log.md — schema, catalog, chronological log

Seeds the wiki with the codebase's own architecture: ApiService, YARP
gateway, schema-per-feature persistence, CQRS+MediatR pipeline, and the
checkout saga. AGENTS.md defines the ingest/query/lint workflows and
page/frontmatter conventions any LLM agent must follow.